### PR TITLE
Created a DTO to break coupling and also to consolidate enum namespac…

### DIFF
--- a/Quibill.DTO/Enums/TransactionType.cs
+++ b/Quibill.DTO/Enums/TransactionType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Quibill.DTO.Enums
+{
+    public enum TransactionType
+    {
+        Withdrawal,
+        Deposit
+    }
+}

--- a/Quibill.DTO/Properties/AssemblyInfo.cs
+++ b/Quibill.DTO/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Quibill.DTO")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Quibill.DTO")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("552c3793-900d-4d24-864d-d378a59c10c2")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Quibill.DTO/Quibill.DTO.csproj
+++ b/Quibill.DTO/Quibill.DTO.csproj
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{552C3793-900D-4D24-864D-D378A59C10C2}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Quibill.DTO</RootNamespace>
+    <AssemblyName>Quibill.DTO</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Enums\TransactionType.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Quibill.sln
+++ b/Quibill.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26206.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quibill.Domain", "src\Quibill.Domain\Quibill.Domain.csproj", "{28918640-F414-4EAF-8858-4F9504A858F8}"
 EndProject
@@ -10,6 +10,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quibill.Domain.Tests", "tests\Quibill.Domain.Tests\Quibill.Domain.Tests.csproj", "{EE326D81-958F-4FEF-8954-22806F2BF424}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quibill.Web.Tests", "tests\Quibill.Web.Tests\Quibill.Web.Tests.csproj", "{9CEF61EC-66E7-4511-9986-6958AF320DBB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Quibill.DTO", "Quibill.DTO\Quibill.DTO.csproj", "{552C3793-900D-4D24-864D-D378A59C10C2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{9CEF61EC-66E7-4511-9986-6958AF320DBB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9CEF61EC-66E7-4511-9986-6958AF320DBB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9CEF61EC-66E7-4511-9986-6958AF320DBB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{552C3793-900D-4D24-864D-D378A59C10C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{552C3793-900D-4D24-864D-D378A59C10C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{552C3793-900D-4D24-864D-D378A59C10C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{552C3793-900D-4D24-864D-D378A59C10C2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Quibill.Domain/Models/ITransaction.cs
+++ b/src/Quibill.Domain/Models/ITransaction.cs
@@ -4,7 +4,7 @@
     {
         int TransactionId { get; }
         decimal TransactionAmount { get;}
-        string TransactionType { get; } // TODO make this an enum?
+        DTO.Enums.TransactionType TransactionType { get; }
         System.DateTime AddDate { get; }
 
     }

--- a/src/Quibill.Domain/Models/RecurringTransaction.cs
+++ b/src/Quibill.Domain/Models/RecurringTransaction.cs
@@ -10,7 +10,7 @@ namespace Quibill.Domain.Models
     {
         public int TransactionId { get; }
         public decimal TransactionAmount { get; }
-        public string TransactionType { get; }
+        public DTO.Enums.TransactionType TransactionType { get; }
         public DateTime AddDate { get; }
 
         public int TransactionRecurrenceDay { get; }

--- a/src/Quibill.Domain/Models/SingleTransaction.cs
+++ b/src/Quibill.Domain/Models/SingleTransaction.cs
@@ -10,7 +10,7 @@ namespace Quibill.Domain
     {
         public int TransactionId { get; }
         public decimal TransactionAmount { get; }
-        public string TransactionType { get; } // TODO make this an enum?
+        public DTO.Enums.TransactionType TransactionType { get; }
         public DateTime AddDate { get; }
 
         public DateTime TransactionDate { get; }

--- a/src/Quibill.Domain/Quibill.Domain.csproj
+++ b/src/Quibill.Domain/Quibill.Domain.csproj
@@ -90,6 +90,12 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Quibill.DTO\Quibill.DTO.csproj">
+      <Project>{552c3793-900d-4d24-864d-d378a59c10c2}</Project>
+      <Name>Quibill.DTO</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Quibill.Web/Quibill.Web.csproj
+++ b/src/Quibill.Web/Quibill.Web.csproj
@@ -301,6 +301,10 @@
     <None Include="Project_Readme.html" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Quibill.DTO\Quibill.DTO.csproj">
+      <Project>{552c3793-900d-4d24-864d-d378a59c10c2}</Project>
+      <Name>Quibill.DTO</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Quibill.Domain\Quibill.Domain.csproj">
       <Project>{28918640-f414-4eaf-8858-4f9504a858f8}</Project>
       <Name>Quibill.Domain</Name>


### PR DESCRIPTION
…e for transaction type etc...

From what I've learned so far, we will use the Data transfer object to communicate between the layers of our application. This will come into play when we start to develop the persistence layer. 

I don't know if we're set up for/need this layer to communicate between our Web and Domain layers, but if nothing else, it provides a great area for us to contain "all" of our (one ;)  ) enums for the project.