### PR TITLE
Issue #15 super user not working correctly

### DIFF
--- a/src/Quibill.Web/Startup.cs
+++ b/src/Quibill.Web/Startup.cs
@@ -14,7 +14,7 @@ namespace Quibill.Web
 {
     public partial class Startup
     {
-        #region Admin Role Credentials
+        #region Super User Role Credentials
         public string AdminUserName
         {
             get
@@ -46,6 +46,7 @@ namespace Quibill.Web
                 return WebConfigurationManager.AppSettings["defaultAdminRole"];
             }
         }
+
         #endregion //Properties to get admin credentials from web.config
 
         public void Configuration(IAppBuilder app)
@@ -76,8 +77,10 @@ namespace Quibill.Web
             //create an Admin super user who will maintain the website from the Web.config file if it doesn't exist.
             if (UserManager.Find(AdminUserName, AdminPassword) == null)
             {
-
                 var user = new ApplicationUser();
+
+                //TODO write code to clean any old super users out of database if the web.config credentials change.
+
                 user.UserName = AdminUserName;
                 user.Email = AdminEmail;
                 string userPassword = AdminPassword;

--- a/src/Quibill.Web/Startup.cs
+++ b/src/Quibill.Web/Startup.cs
@@ -71,8 +71,11 @@ namespace Quibill.Web
                 var role = new IdentityRole();
                 role.Name = AdminRole;
                 roleManager.Create(role);
+            }
 
-                //create an Admin super user who will maintain the website
+            //create an Admin super user who will maintain the website from the Web.config file if it doesn't exist.
+            if (UserManager.Find(AdminUserName, AdminPassword) == null)
+            {
 
                 var user = new ApplicationUser();
                 user.UserName = AdminUserName;
@@ -87,7 +90,7 @@ namespace Quibill.Web
                     var result1 = UserManager.AddToRole(user.Id, AdminRole);
                 }
 
-                //TODO create other roles besides Admin.
+                //TODO create other roles besides Admin.\
             }
         }
     }

--- a/src/Quibill.Web/Web.config
+++ b/src/Quibill.Web/Web.config
@@ -12,7 +12,7 @@
     <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\Quibill.Web.mdf;Initial Catalog=Quibill.Web;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
-    <add key="defaultAdminUserName" value="Baruch.Oltman@gmail.com"/>
+    <add key="defaultAdminUserName" value="Admin1"/>
     <add key="defaultAdminEmail" value="Baruch.Oltman@gmail.com"/>
     <add key="defaultAdminPassword" value="200785Sg1abc."/>
     <add key="defaultAdminRole" value="Admin"/>

--- a/src/Quibill.Web/Web.config
+++ b/src/Quibill.Web/Web.config
@@ -12,7 +12,7 @@
     <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\Quibill.Web.mdf;Initial Catalog=Quibill.Web;Integrated Security=True" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
-    <add key="defaultAdminUserName" value="Admin"/>
+    <add key="defaultAdminUserName" value="Baruch.Oltman@gmail.com"/>
     <add key="defaultAdminEmail" value="Baruch.Oltman@gmail.com"/>
     <add key="defaultAdminPassword" value="200785Sg1abc."/>
     <add key="defaultAdminRole" value="Admin"/>


### PR DESCRIPTION
Fixed. The create super user code dependent on the Admin role existing, so if the user was ever deleted from the database, but the Admin role was not, the user would never be created.

I tried writing code that would delete all old super users from the database whenever the web.config credentials were changed, but I couldn't figure it out. I added a reminder TODO comment.